### PR TITLE
Update to wrong install command in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ fork of [thelounge's zenburn](https://github.com/thelounge/thelounge/blob/v3.0.0
 you should be able to install this with:
 
 ```
-thelounge install thelounge-theme-zenburn-monospace
+thelounge install thelounge-theme-gruvbox
 ```
 
 ![](preview.png)


### PR DESCRIPTION
Really simple fix to change the install command so it is correct (current one installs the theme it was forked from not the new theme).